### PR TITLE
feat(home-assistant): integrate lovelace-layout-card for responsive views

### DIFF
--- a/roles/home-assistant/files/configuration.yaml
+++ b/roles/home-assistant/files/configuration.yaml
@@ -26,3 +26,5 @@ lovelace:
       type: module
     - url: /local/text-divider-row/text-divider-row.js?v=1
       type: module
+    - url: /local/lovelace-layout-card/layout-card.js?v=1
+      type: module

--- a/roles/home-assistant/files/views/01-home.yaml
+++ b/roles/home-assistant/files/views/01-home.yaml
@@ -5,182 +5,195 @@ theme: Google - Dark
 panel: true
 badges: []
 cards:
-  - type: horizontal-stack
-    cards:
-      - type: vertical-stack
-        cards:
-          - type: media-control
-            entity: media_player.spotify_pascal_iske
-            card_mod:
-              style: |
-                .background .color-block, .background .no-img, .background .image {
-                  background: inherit;
-                }
-          - type: weather-forecast
-            entity: weather.home
-          - type: sensor
-            entity: sensor.rodgau_nieder_roden_to_westend_frankfurt_a_m
-            name: S1 → Westend
-          - type: horizontal-stack
-            cards:
-              - type: sensor
-                name: Weight Pascal
-                graph: line
-                icon: mdi:scale-bathroom
-                hours_to_show: 168
-                entity: sensor.withings_weight_kg_pascal_iske
-              - type: sensor
-                name: Weight Sarah
-                graph: line
-                icon: mdi:scale-bathroom
-                hours_to_show: 168
-                entity: sensor.withings_weight_kg_sarah_iske
-      - type: vertical-stack
-        cards:
-          - type: entity-filter
-            show_empty: false
-            state_filter:
-              - operator: '!='
-                value: 'unavailable'
-            card:
-              title: Entrance
-              state_color: false
-              show_header_toggle: false
-            entities:
-              - entity: binary_sensor.entrance_lumi_magnet_on_off
-                secondary_info: last-changed
-                icon: mdi:door
-                name: Door
-              - entity: sensor.entrance_lumi_magnet_power
-                secondary_info: last-changed
-                name: Battery
-          - type: entity-filter
-            show_empty: false
-            state_filter:
-              - operator: '!='
-                value: 'unavailable'
-            card:
-              title: Living Room
-              state_color: true
-              show_header_toggle: true
-            entities:
-              - entity: sensor.living_room_lumi_temperature
-                secondary_info: last-changed
-                name: Temperature
-              - entity: sensor.living_room_lumi_humidity
-                secondary_info: last-changed
-                name: Humidity
-              - entity: sensor.living_room_lumi_power
-                secondary_info: last-changed
-                name: Battery
-              - type: custom:text-divider-row
-                entity: sensor.time
-                text: Lights
-                card_mod:
-                  style: |
-                    h2.text-divider {
-                      font-weight: normal;
-                      letter-spacing: 0.5px;
-                      opacity: .5;
-                    }
-              - entity: switch.lampe
-                secondary_info: last-changed
-              - entity: switch.duftlampe
-                secondary_info: last-changed
-          - type: entity-filter
-            show_empty: false
-            state_filter:
-              - operator: '!='
-                value: 'unavailable'
-            card:
-              title: Kitchen
-              state_color: true
-              show_header_toggle: true
-            entities:
-              - entity: switch.lichterkette
-                secondary_info: last-changed
-      - type: vertical-stack
-        cards:
-          - type: entity-filter
-            show_empty: false
-            state_filter:
-              - operator: '!='
-                value: 'unavailable'
-            card:
-              title: Bedroom
-              state_color: true
-              show_header_toggle: true
-            entities:
-              - entity: sensor.bed_room_lumi_temperature
-                secondary_info: last-changed
-                name: Temperature
-              - entity: sensor.bed_room_lumi_humidity
-                secondary_info: last-changed
-                name: Humidity
-              - entity: sensor.bed_room_lumi_power
-                secondary_info: last-changed
-                name: Battery
-              - type: custom:text-divider-row
-                entity: sensor.time
-                text: Lights
-                card_mod:
-                  style: |
-                    h2.text-divider {
-                      font-weight: normal;
-                      letter-spacing: 0.5px;
-                      opacity: .5;
-                    }
-              - entity: switch.licht
-                secondary_info: last-changed
-          - type: entity-filter
-            show_empty: false
-            state_filter:
-              - operator: '!='
-                value: 'unavailable'
-            card:
-              title: Childrens Room
-              state_color: true
-              show_header_toggle: true
-            entities:
-              - entity: sensor.childrens_room_lumi_temperature
-                secondary_info: last-changed
-                name: Temperature
-              - entity: sensor.childrens_room_lumi_humidity
-                secondary_info: last-changed
-                name: Humidity
-              - entity: sensor.childrens_room_lumi_power
-                secondary_info: last-changed
-                name: Battery
-              - type: custom:text-divider-row
-                entity: sensor.time
-                text: Lights
-                card_mod:
-                  style: |
-                    h2.text-divider {
-                      font-weight: normal;
-                      letter-spacing: 0.5px;
-                      opacity: .5;
-                    }
-              - entity: switch.love
-                secondary_info: last-changed
-              - entity: switch.kugel
-                secondary_info: last-changed
-          - type: entity-filter
-            show_empty: false
-            state_filter:
-              - operator: '!='
-                value: 'unavailable'
-            card:
-              title: Bathroom
-              state_color: true
-              show_header_toggle: true
-            entities:
-              - entity: sensor.bathroom_lumi_temperature
-                secondary_info: last-changed
-                name: Temperature
-              - entity: sensor.bathroom_lumi_humidity
-                secondary_info: last-changed
-                name: Humidity
-              - entity: sensor.bathroom_lumi_power
-                secondary_info: last-changed
-                name: Battery
+  - type: custom:mod-card
+    card:
+      type: custom:layout-card
+      layout_type: custom:horizontal-layout
+      layout:
+        max_width: 1000
+      cards:
+        - type: vertical-stack
+          cards:
+            - type: media-control
+              entity: media_player.spotify_pascal_iske
+              card_mod:
+                style: |
+                  .background .color-block, .background .no-img, .background .image {
+                    background: inherit;
+                  }
+            - type: weather-forecast
+              entity: weather.home
+            - type: sensor
+              entity: sensor.rodgau_nieder_roden_to_westend_frankfurt_a_m
+              name: S1 → Westend
+            - type: horizontal-stack
+              cards:
+                - type: sensor
+                  name: Weight Pascal
+                  graph: line
+                  icon: mdi:scale-bathroom
+                  hours_to_show: 168
+                  entity: sensor.withings_weight_kg_pascal_iske
+                - type: sensor
+                  name: Weight Sarah
+                  graph: line
+                  icon: mdi:scale-bathroom
+                  hours_to_show: 168
+                  entity: sensor.withings_weight_kg_sarah_iske
+        - type: vertical-stack
+          cards:
+            - type: entity-filter
+              show_empty: false
+              state_filter:
+                - operator: '!='
+                  value: 'unavailable'
+              card:
+                title: Entrance
+                state_color: false
+                show_header_toggle: false
+              entities:
+                - entity: binary_sensor.entrance_lumi_magnet_on_off
+                  secondary_info: last-changed
+                  icon: mdi:door
+                  name: Door
+                - entity: sensor.entrance_lumi_magnet_power
+                  secondary_info: last-changed
+                  name: Battery
+            - type: entity-filter
+              show_empty: false
+              state_filter:
+                - operator: '!='
+                  value: 'unavailable'
+              card:
+                title: Living Room
+                state_color: true
+                show_header_toggle: true
+              entities:
+                - entity: sensor.living_room_lumi_temperature
+                  secondary_info: last-changed
+                  name: Temperature
+                - entity: sensor.living_room_lumi_humidity
+                  secondary_info: last-changed
+                  name: Humidity
+                - entity: sensor.living_room_lumi_power
+                  secondary_info: last-changed
+                  name: Battery
+                - type: custom:text-divider-row
+                  entity: sensor.time
+                  text: Lights
+                  card_mod:
+                    style: |
+                      h2.text-divider {
+                        font-weight: normal;
+                        letter-spacing: 0.5px;
+                        opacity: .5;
+                      }
+                - entity: switch.lampe
+                  secondary_info: last-changed
+                - entity: switch.duftlampe
+                  secondary_info: last-changed
+            - type: entity-filter
+              show_empty: false
+              state_filter:
+                - operator: '!='
+                  value: 'unavailable'
+              card:
+                title: Kitchen
+                state_color: true
+                show_header_toggle: true
+              entities:
+                - entity: switch.lichterkette
+                  secondary_info: last-changed
+        - type: vertical-stack
+          cards:
+            - type: entity-filter
+              show_empty: false
+              state_filter:
+                - operator: '!='
+                  value: 'unavailable'
+              card:
+                title: Bedroom
+                state_color: true
+                show_header_toggle: true
+              entities:
+                - entity: sensor.bed_room_lumi_temperature
+                  secondary_info: last-changed
+                  name: Temperature
+                - entity: sensor.bed_room_lumi_humidity
+                  secondary_info: last-changed
+                  name: Humidity
+                - entity: sensor.bed_room_lumi_power
+                  secondary_info: last-changed
+                  name: Battery
+                - type: custom:text-divider-row
+                  entity: sensor.time
+                  text: Lights
+                  card_mod:
+                    style: |
+                      h2.text-divider {
+                        font-weight: normal;
+                        letter-spacing: 0.5px;
+                        opacity: .5;
+                      }
+                - entity: switch.licht
+                  secondary_info: last-changed
+            - type: entity-filter
+              show_empty: false
+              state_filter:
+                - operator: '!='
+                  value: 'unavailable'
+              card:
+                title: Childrens Room
+                state_color: true
+                show_header_toggle: true
+              entities:
+                - entity: sensor.childrens_room_lumi_temperature
+                  secondary_info: last-changed
+                  name: Temperature
+                - entity: sensor.childrens_room_lumi_humidity
+                  secondary_info: last-changed
+                  name: Humidity
+                - entity: sensor.childrens_room_lumi_power
+                  secondary_info: last-changed
+                  name: Battery
+                - type: custom:text-divider-row
+                  entity: sensor.time
+                  text: Lights
+                  card_mod:
+                    style: |
+                      h2.text-divider {
+                        font-weight: normal;
+                        letter-spacing: 0.5px;
+                        opacity: .5;
+                      }
+                - entity: switch.love
+                  secondary_info: last-changed
+                - entity: switch.kugel
+                  secondary_info: last-changed
+            - type: entity-filter
+              show_empty: false
+              state_filter:
+                - operator: '!='
+                  value: 'unavailable'
+              card:
+                title: Bathroom
+                state_color: true
+                show_header_toggle: true
+              entities:
+                - entity: sensor.bathroom_lumi_temperature
+                  secondary_info: last-changed
+                  name: Temperature
+                - entity: sensor.bathroom_lumi_humidity
+                  secondary_info: last-changed
+                  name: Humidity
+                - entity: sensor.bathroom_lumi_power
+                  secondary_info: last-changed
+                  name: Battery
+    card_mod:
+      style: |
+        ha-card {
+          margin-top: -8px;
+          margin-right: -8px;
+          margin-left: -7px;
+          transition: none;
+        }

--- a/roles/home-assistant/files/views/02-childrens-room.yaml
+++ b/roles/home-assistant/files/views/02-childrens-room.yaml
@@ -5,39 +5,52 @@ theme: Google - Dark
 panel: true
 badges: []
 cards:
-  - type: horizontal-stack
-    cards:
-      - type: vertical-stack
-        cards:
-          - type: entities
-            title: Climate
-            state_color: false
-            show_header_toggle: false
-            entities:
-              - entity: sensor.childrens_room_lumi_temperature
-                secondary_info: last-changed
-                name: Temperature
-              - entity: sensor.childrens_room_lumi_humidity
-                secondary_info: last-changed
-                name: Humidity
-              - entity: sensor.childrens_room_lumi_pressure
-                secondary_info: last-changed
-                name: Pressure
-              - entity: sensor.childrens_room_lumi_power
-                secondary_info: last-changed
-                name: Battery
-            footer:
-              type: graph
-              entity: sensor.childrens_room_lumi_temperature
-              hours_to_show: 48
-      - type: vertical-stack
-        cards:
-          - type: entities
-            title: Lights
-            state_color: true
-            show_header_toggle: true
-            entities:
-              - entity: switch.love
-                secondary_info: last-changed
-              - entity: switch.kugel
-                secondary_info: last-changed
+  - type: custom:mod-card
+    card:
+      type: custom:layout-card
+      layout_type: custom:horizontal-layout
+      layout:
+        max_width: 1000
+      cards:
+        - type: vertical-stack
+          cards:
+            - type: entities
+              title: Climate
+              state_color: false
+              show_header_toggle: false
+              entities:
+                - entity: sensor.childrens_room_lumi_temperature
+                  secondary_info: last-changed
+                  name: Temperature
+                - entity: sensor.childrens_room_lumi_humidity
+                  secondary_info: last-changed
+                  name: Humidity
+                - entity: sensor.childrens_room_lumi_pressure
+                  secondary_info: last-changed
+                  name: Pressure
+                - entity: sensor.childrens_room_lumi_power
+                  secondary_info: last-changed
+                  name: Battery
+              footer:
+                type: graph
+                entity: sensor.childrens_room_lumi_temperature
+                hours_to_show: 48
+        - type: vertical-stack
+          cards:
+            - type: entities
+              title: Lights
+              state_color: true
+              show_header_toggle: true
+              entities:
+                - entity: switch.love
+                  secondary_info: last-changed
+                - entity: switch.kugel
+                  secondary_info: last-changed
+    card_mod:
+      style: |
+        ha-card {
+          margin-top: -8px;
+          margin-right: -8px;
+          margin-left: -7px;
+          transition: none;
+        }

--- a/roles/home-assistant/files/views/03-bedroom.yaml
+++ b/roles/home-assistant/files/views/03-bedroom.yaml
@@ -5,37 +5,50 @@ theme: Google - Dark
 panel: true
 badges: []
 cards:
-  - type: horizontal-stack
-    cards:
-      - type: vertical-stack
-        cards:
-          - type: entities
-            title: Climate
-            state_color: false
-            show_header_toggle: false
-            entities:
-              - entity: sensor.bed_room_lumi_temperature
-                secondary_info: last-changed
-                name: Temperature
-              - entity: sensor.bed_room_lumi_humidity
-                secondary_info: last-changed
-                name: Humidity
-              - entity: sensor.bed_room_lumi_pressure
-                secondary_info: last-changed
-                name: Pressure
-              - entity: sensor.bed_room_lumi_power
-                secondary_info: last-changed
-                name: Battery
-            footer:
-              type: graph
-              entity: sensor.bed_room_lumi_temperature
-              hours_to_show: 48
-      - type: vertical-stack
-        cards:
-          - type: entities
-            title: Lights
-            state_color: true
-            show_header_toggle: true
-            entities:
-              - entity: switch.licht
-                secondary_info: last-changed
+  - type: custom:mod-card
+    card:
+      type: custom:layout-card
+      layout_type: custom:horizontal-layout
+      layout:
+        max_width: 1000
+      cards:
+        - type: vertical-stack
+          cards:
+            - type: entities
+              title: Climate
+              state_color: false
+              show_header_toggle: false
+              entities:
+                - entity: sensor.bed_room_lumi_temperature
+                  secondary_info: last-changed
+                  name: Temperature
+                - entity: sensor.bed_room_lumi_humidity
+                  secondary_info: last-changed
+                  name: Humidity
+                - entity: sensor.bed_room_lumi_pressure
+                  secondary_info: last-changed
+                  name: Pressure
+                - entity: sensor.bed_room_lumi_power
+                  secondary_info: last-changed
+                  name: Battery
+              footer:
+                type: graph
+                entity: sensor.bed_room_lumi_temperature
+                hours_to_show: 48
+        - type: vertical-stack
+          cards:
+            - type: entities
+              title: Lights
+              state_color: true
+              show_header_toggle: true
+              entities:
+                - entity: switch.licht
+                  secondary_info: last-changed
+    card_mod:
+      style: |
+        ha-card {
+          margin-top: -8px;
+          margin-right: -8px;
+          margin-left: -7px;
+          transition: none;
+        }

--- a/roles/home-assistant/files/views/04-living-room.yaml
+++ b/roles/home-assistant/files/views/04-living-room.yaml
@@ -5,39 +5,52 @@ theme: Google - Dark
 panel: true
 badges: []
 cards:
-  - type: horizontal-stack
-    cards:
-      - type: vertical-stack
-        cards:
-          - type: entities
-            title: Climate
-            state_color: false
-            show_header_toggle: false
-            entities:
-              - entity: sensor.living_room_lumi_temperature
-                secondary_info: last-changed
-                name: Temperature
-              - entity: sensor.living_room_lumi_humidity
-                secondary_info: last-changed
-                name: Humidity
-              - entity: sensor.living_room_lumi_pressure
-                secondary_info: last-changed
-                name: Pressure
-              - entity: sensor.living_room_lumi_power
-                secondary_info: last-changed
-                name: Battery
-            footer:
-              type: graph
-              entity: sensor.living_room_lumi_temperature
-              hours_to_show: 48
-      - type: vertical-stack
-        cards:
-          - type: entities
-            title: Lights
-            state_color: true
-            show_header_toggle: true
-            entities:
-              - entity: switch.lampe
-                secondary_info: last-changed
-              - entity: switch.duftlampe
-                secondary_info: last-changed
+  - type: custom:mod-card
+    card:
+      type: custom:layout-card
+      layout_type: custom:horizontal-layout
+      layout:
+        max_width: 1000
+      cards:
+        - type: vertical-stack
+          cards:
+            - type: entities
+              title: Climate
+              state_color: false
+              show_header_toggle: false
+              entities:
+                - entity: sensor.living_room_lumi_temperature
+                  secondary_info: last-changed
+                  name: Temperature
+                - entity: sensor.living_room_lumi_humidity
+                  secondary_info: last-changed
+                  name: Humidity
+                - entity: sensor.living_room_lumi_pressure
+                  secondary_info: last-changed
+                  name: Pressure
+                - entity: sensor.living_room_lumi_power
+                  secondary_info: last-changed
+                  name: Battery
+              footer:
+                type: graph
+                entity: sensor.living_room_lumi_temperature
+                hours_to_show: 48
+        - type: vertical-stack
+          cards:
+            - type: entities
+              title: Lights
+              state_color: true
+              show_header_toggle: true
+              entities:
+                - entity: switch.lampe
+                  secondary_info: last-changed
+                - entity: switch.duftlampe
+                  secondary_info: last-changed
+    card_mod:
+      style: |
+        ha-card {
+          margin-top: -8px;
+          margin-right: -8px;
+          margin-left: -7px;
+          transition: none;
+        }

--- a/roles/home-assistant/files/views/05-bathroom.yaml
+++ b/roles/home-assistant/files/views/05-bathroom.yaml
@@ -5,28 +5,41 @@ theme: Google - Dark
 panel: true
 badges: []
 cards:
-  - type: horizontal-stack
-    cards:
-      - type: vertical-stack
-        cards:
-          - type: entities
-            title: Climate
-            state_color: false
-            show_header_toggle: false
-            entities:
-              - entity: sensor.bathroom_lumi_temperature
-                secondary_info: last-changed
-                name: Temperature
-              - entity: sensor.bathroom_lumi_humidity
-                secondary_info: last-changed
-                name: Humidity
-              - entity: sensor.bathroom_lumi_pressure
-                secondary_info: last-changed
-                name: Pressure
-              - entity: sensor.bathroom_lumi_power
-                secondary_info: last-changed
-                name: Battery
-            footer:
-              type: graph
-              entity: sensor.bathroom_lumi_temperature
-              hours_to_show: 48
+  - type: custom:mod-card
+    card:
+      type: custom:layout-card
+      layout_type: custom:horizontal-layout
+      layout:
+        max_width: 1000
+      cards:
+        - type: vertical-stack
+          cards:
+            - type: entities
+              title: Climate
+              state_color: false
+              show_header_toggle: false
+              entities:
+                - entity: sensor.bathroom_lumi_temperature
+                  secondary_info: last-changed
+                  name: Temperature
+                - entity: sensor.bathroom_lumi_humidity
+                  secondary_info: last-changed
+                  name: Humidity
+                - entity: sensor.bathroom_lumi_pressure
+                  secondary_info: last-changed
+                  name: Pressure
+                - entity: sensor.bathroom_lumi_power
+                  secondary_info: last-changed
+                  name: Battery
+              footer:
+                type: graph
+                entity: sensor.bathroom_lumi_temperature
+                hours_to_show: 48
+    card_mod:
+      style: |
+        ha-card {
+          margin-top: -8px;
+          margin-right: -8px;
+          margin-left: -7px;
+          transition: none;
+        }

--- a/roles/home-assistant/files/views/06-kitchen.yaml
+++ b/roles/home-assistant/files/views/06-kitchen.yaml
@@ -5,14 +5,27 @@ theme: Google - Dark
 panel: true
 badges: []
 cards:
-  - type: horizontal-stack
-    cards:
-      - type: vertical-stack
-        cards:
-          - type: entities
-            title: Lights
-            state_color: true
-            show_header_toggle: true
-            entities:
-              - entity: switch.lichterkette
-                secondary_info: last-changed
+  - type: custom:mod-card
+    card:
+      type: custom:layout-card
+      layout_type: custom:horizontal-layout
+      layout:
+        max_width: 1000
+      cards:
+        - type: vertical-stack
+          cards:
+            - type: entities
+              title: Lights
+              state_color: true
+              show_header_toggle: true
+              entities:
+                - entity: switch.lichterkette
+                  secondary_info: last-changed
+    card_mod:
+      style: |
+        ha-card {
+          margin-top: -8px;
+          margin-right: -8px;
+          margin-left: -7px;
+          transition: none;
+        }

--- a/roles/home-assistant/files/views/07-tech.yaml
+++ b/roles/home-assistant/files/views/07-tech.yaml
@@ -5,175 +5,188 @@ theme: Google - Dark
 panel: true
 badges: []
 cards:
-  - type: horizontal-stack
-    cards:
-      - type: vertical-stack
-        cards:
-          - type: horizontal-stack
-            cards:
-              - type: sensor
-                name: Public IP
-                graph: none
-                icon: mdi:web
-                entity: sensor.fritzbox_public_ip
-              - type: sensor
-                name: Last Boot
-                graph: none
-                icon: mdi:clock-outline
-                entity: sensor.relative_last_boot
-          - type: horizontal-stack
-            cards:
-              - type: sensor
-                name: Downstream
-                graph: none
-                icon: mdi:arrow-down
-                entity: sensor.fritzbox_downstream_percentage
-              - type: sensor
-                name: Upstream
-                graph: none
-                icon: mdi:arrow-up
-                entity: sensor.fritzbox_upstream_percentage
-              - type: sensor
-                name: Uptime
-                graph: none
-                icon: mdi:clock-outline
-                entity: sensor.fritzbox_uptime
-          - type: entities
-            title: Ad Blocker
-            show_header_toggle: false
-            entities:
-              - entity: switch.pi_hole
-                type: custom:multiple-entity-row
-                name: Enabled
-                secondary_info: last-changed
-                toggle: true
-                tap_action:
-                  action: url
-                  url_path: !secret pi_hole_url
-                entities:
-                  - entity: sensor.pi_hole_ads_percentage_blocked_today
-                    name: Percentage
-                  - entity: sensor.pi_hole_ads_blocked_today
-                    name: Queries
-                    unit: false
-                  - entity: sensor.pi_hole_domains_blocked
-                    name: Blocklist
-                    unit: false
-              - type: divider
-                style:
-                  height: 10px;
-            footer:
-              type: graph
-              entity: sensor.pi_hole_ads_percentage_blocked_today
-              hours_to_show: 168
-          - type: entity-filter
-            show_empty: false
-            state_filter:
-              - operator: '!='
-                value: 'unavailable'
-            card:
-              type: entities
-              title: Printer
-              icon: mdi:printer
+  - type: custom:mod-card
+    card:
+      type: custom:layout-card
+      layout_type: custom:horizontal-layout
+      layout:
+        max_width: 1000
+      cards:
+        - type: vertical-stack
+          cards:
+            - type: horizontal-stack
+              cards:
+                - type: sensor
+                  name: Public IP
+                  graph: none
+                  icon: mdi:web
+                  entity: sensor.fritzbox_public_ip
+                - type: sensor
+                  name: Last Boot
+                  graph: none
+                  icon: mdi:clock-outline
+                  entity: sensor.relative_last_boot
+            - type: horizontal-stack
+              cards:
+                - type: sensor
+                  name: Downstream
+                  graph: none
+                  icon: mdi:arrow-down
+                  entity: sensor.fritzbox_downstream_percentage
+                - type: sensor
+                  name: Upstream
+                  graph: none
+                  icon: mdi:arrow-up
+                  entity: sensor.fritzbox_upstream_percentage
+                - type: sensor
+                  name: Uptime
+                  graph: none
+                  icon: mdi:clock-outline
+                  entity: sensor.fritzbox_uptime
+            - type: entities
+              title: Ad Blocker
               show_header_toggle: false
-              entities: []
-            entities:
-              - entity: sensor.epson_et_2750_series
-              - entity: sensor.epson_et_2750_series_black_ink
-              - entity: sensor.epson_et_2750_series_cyan_ink
-              - entity: sensor.epson_et_2750_series_magenta_ink
-              - entity: sensor.epson_et_2750_series_yellow_ink
-      - type: vertical-stack
-        cards:
-          - type: entity-filter
-            state_filter:
-              - operator: '!='
-                value: 'unavailable'
-            card:
-              type: entities
-              title: GitLab
+              entities:
+                - entity: switch.pi_hole
+                  type: custom:multiple-entity-row
+                  name: Enabled
+                  secondary_info: last-changed
+                  toggle: true
+                  tap_action:
+                    action: url
+                    url_path: !secret pi_hole_url
+                  entities:
+                    - entity: sensor.pi_hole_ads_percentage_blocked_today
+                      name: Percentage
+                    - entity: sensor.pi_hole_ads_blocked_today
+                      name: Queries
+                      unit: false
+                    - entity: sensor.pi_hole_domains_blocked
+                      name: Blocklist
+                      unit: false
+                - type: divider
+                  style:
+                    height: 10px;
+              footer:
+                type: graph
+                entity: sensor.pi_hole_ads_percentage_blocked_today
+                hours_to_show: 168
+            - type: entity-filter
+              show_empty: false
+              state_filter:
+                - operator: '!='
+                  value: 'unavailable'
+              card:
+                type: entities
+                title: Printer
+                icon: mdi:printer
+                show_header_toggle: false
+                entities: []
+              entities:
+                - entity: sensor.epson_et_2750_series
+                - entity: sensor.epson_et_2750_series_black_ink
+                - entity: sensor.epson_et_2750_series_cyan_ink
+                - entity: sensor.epson_et_2750_series_magenta_ink
+                - entity: sensor.epson_et_2750_series_yellow_ink
+        - type: vertical-stack
+          cards:
+            - type: entity-filter
+              state_filter:
+                - operator: '!='
+                  value: 'unavailable'
+              card:
+                type: entities
+                title: GitLab
+                show_header_toggle: false
+              entities:
+                - entity: sensor.glances_gitlab_rootfs_used_percent
+                  name: Disk usage
+                - entity: sensor.glances_gitlab_rootfs_free
+                  name: Disk space left
+                - entity: sensor.glances_gitlab_cpu_load
+                  name: CPU Load
+                - entity: sensor.glances_gitlab_containers_active
+                  name: Containers
+                - entity: sensor.glances_gitlab_containers_cpu_used
+                  name: Docker CPU usage
+                - entity: sensor.glances_gitlab_containers_ram_used
+                  name: Docker Memory usage
+            - type: entity-filter
+              show_empty: false
+              state_filter:
+                - operator: '!='
+                  value: 'unavailable'
+              card:
+                type: custom:mini-graph-card
+                name: Metrics
+                aggregate_func: max
+                group_by: hour
+                animate: true
+                line_width: 3
+                align_state: center
+              card_mod:
+                style: |
+                  .header .name, .header .name .ellipsis {
+                    color: #d7d7d7;
+                    font-family: var(--ha-card-header-font-family, inherit);
+                    font-size: var(--ha-card-header-font-size, 24px);
+                    letter-spacing: -0.012em;
+                    line-height: 32px;
+                    opacity: 1;
+                  }
+              tap_action:
+                action: url
+                url_path: !secret glances_gitlab_url
+              entities:
+                - entity: sensor.glances_gitlab_cpu_used
+                  name: CPU usage
+                - entity: sensor.glances_gitlab_ram_used_percent
+                  name: Memory usage
+                  y_axis: secondary
+                - entity: sensor.glances_gitlab_swap_used_percent
+                  name: Swap usage
+                  y_axis: secondary
+            - type: entities
+              title: Pipelines
               show_header_toggle: false
-            entities:
-              - entity: sensor.glances_gitlab_rootfs_used_percent
-                name: Disk usage
-              - entity: sensor.glances_gitlab_rootfs_free
-                name: Disk space left
-              - entity: sensor.glances_gitlab_cpu_load
-                name: CPU Load
-              - entity: sensor.glances_gitlab_containers_active
-                name: Containers
-              - entity: sensor.glances_gitlab_containers_cpu_used
-                name: Docker CPU usage
-              - entity: sensor.glances_gitlab_containers_ram_used
-                name: Docker Memory usage
-          - type: entity-filter
-            show_empty: false
-            state_filter:
-              - operator: '!='
-                value: 'unavailable'
-            card:
-              type: custom:mini-graph-card
-              name: Metrics
-              aggregate_func: max
-              group_by: hour
-              animate: true
-              line_width: 3
-              align_state: center
-            card_mod:
-              style: |
-                .header .name, .header .name .ellipsis {
-                  color: #d7d7d7;
-                  font-family: var(--ha-card-header-font-family, inherit);
-                  font-size: var(--ha-card-header-font-size, 24px);
-                  letter-spacing: -0.012em;
-                  line-height: 32px;
-                  opacity: 1;
-                }
-            tap_action:
-              action: url
-              url_path: !secret glances_gitlab_url
-            entities:
-              - entity: sensor.glances_gitlab_cpu_used
-                name: CPU usage
-              - entity: sensor.glances_gitlab_ram_used_percent
-                name: Memory usage
-                y_axis: secondary
-              - entity: sensor.glances_gitlab_swap_used_percent
-                name: Swap usage
-                y_axis: secondary
-          - type: entities
-            title: Pipelines
-            show_header_toggle: false
-            entities:
-              - entity: sensor.jh_of_app
-                name: pi-webdesign/jh-of/app
-                tap_action:
-                  action: url
-                  url_path: https://git.pascaliske.dev/pi-webdesign/jh-of/app
-              - entity: sensor.jh_of_api
-                name: pi-webdesign/jh-of/api
-                tap_action:
-                  action: url
-                  url_path: https://git.pascaliske.dev/pi-webdesign/jh-of/api
-      - type: vertical-stack
-        cards:
-          - type: entities
-            title: Certificates
-            show_header_toggle: false
-            entities:
-              - entity: sensor.cert_expiry_pascaliske_dev
-                name: pascaliske.dev
-              - entity: sensor.cert_expiry_git_pascaliske_dev
-                name: git.pascaliske.dev
-              - entity: sensor.cert_expiry_registry_pascaliske_dev
-                name: registry.pascaliske.dev
-              - entity: sensor.cert_expiry_stats_pascaliske_dev
-                name: stats.pascaliske.dev
-              - entity: sensor.cert_expiry_logs_pascaliske_dev
-                name: logs.pascaliske.dev
-              - entity: sensor.cert_expiry_code_pascaliske_dev
-                name: code.pascaliske.dev
-              - entity: sensor.cert_expiry_go_pascaliske_dev
-                name: go.pascaliske.dev
-              - entity: sensor.cert_expiry_portainer_pascaliske_dev
-                name: portainer.pascaliske.dev
+              entities:
+                - entity: sensor.jh_of_app
+                  name: pi-webdesign/jh-of/app
+                  tap_action:
+                    action: url
+                    url_path: https://git.pascaliske.dev/pi-webdesign/jh-of/app
+                - entity: sensor.jh_of_api
+                  name: pi-webdesign/jh-of/api
+                  tap_action:
+                    action: url
+                    url_path: https://git.pascaliske.dev/pi-webdesign/jh-of/api
+        - type: vertical-stack
+          cards:
+            - type: entities
+              title: Certificates
+              show_header_toggle: false
+              entities:
+                - entity: sensor.cert_expiry_pascaliske_dev
+                  name: pascaliske.dev
+                - entity: sensor.cert_expiry_git_pascaliske_dev
+                  name: git.pascaliske.dev
+                - entity: sensor.cert_expiry_registry_pascaliske_dev
+                  name: registry.pascaliske.dev
+                - entity: sensor.cert_expiry_stats_pascaliske_dev
+                  name: stats.pascaliske.dev
+                - entity: sensor.cert_expiry_logs_pascaliske_dev
+                  name: logs.pascaliske.dev
+                - entity: sensor.cert_expiry_code_pascaliske_dev
+                  name: code.pascaliske.dev
+                - entity: sensor.cert_expiry_go_pascaliske_dev
+                  name: go.pascaliske.dev
+                - entity: sensor.cert_expiry_portainer_pascaliske_dev
+                  name: portainer.pascaliske.dev
+    card_mod:
+      style: |
+        ha-card {
+          margin-top: -8px;
+          margin-right: -8px;
+          margin-left: -7px;
+          transition: none;
+        }

--- a/roles/home-assistant/tasks/main.yml
+++ b/roles/home-assistant/tasks/main.yml
@@ -59,6 +59,7 @@
     - { user: 'cbulock', repo: 'lovelace-battery-entity' }
     - { user: 'thomasloven', repo: 'lovelace-card-mod' }
     - { user: 'thomasloven', repo: 'lovelace-slider-entity-row' }
+    - { user: 'thomasloven', repo: 'lovelace-layout-card' }
 
 - name: Download plugins into plugin directory
   vars:


### PR DESCRIPTION
- [ ] Integrate https://github.com/thomasloven/lovelace-layout-card
- [ ] Refactor views for `custom:layout-card` with `layout_type: custom:horizontal-layout`
- [ ] Use https://github.com/thomasloven/lovelace-card-mod to remove double margins from layout card:

```yaml
card_mod:
  style: |
    ha-card {
      margin-top: -8px;
      margin-right: -8px;
      margin-left: -7px;
      transition: none;
    }
```