### PR TITLE
feat(cert-manager): integrate cert-manager service into cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 This repository contains the configurations for most of my services:
 
 - [Traefik](https://traefik.io) reverse proxy for all services
+- [cert-manager](https://cert-manager.io) as automated certificate management tool
 - [Authelia](https://www.authelia.com) as SSO platform for all services
 - [Homer](https://github.com/bastienwirtz/homer) as service dashboard
 - [Prometheus](https://prometheus.io) for collecting service metrics

--- a/infrastructure.code-workspace
+++ b/infrastructure.code-workspace
@@ -15,6 +15,10 @@
             "name": "roles/autorestic"
         },
         {
+            "path": "./roles/cert-manager",
+            "name": "roles/cert-manager"
+        },
+        {
             "path": "./roles/cloudflared",
             "name": "roles/cloudflared"
         },

--- a/playbooks/network/configure.yml
+++ b/playbooks/network/configure.yml
@@ -8,6 +8,9 @@
     - role: k3s
       tags:
         - k3s
+    - role: cert-manager
+      tags:
+        - cert-manager
     - role: keel
       tags:
         - keel

--- a/playbooks/remote/configure.yml
+++ b/playbooks/remote/configure.yml
@@ -8,6 +8,9 @@
     - role: k3s
       tags:
         - k3s
+    - role: cert-manager
+      tags:
+        - cert-manager
     - role: traefik
       tags:
         - traefik

--- a/roles/authelia/tasks/main.yml
+++ b/roles/authelia/tasks/main.yml
@@ -41,6 +41,9 @@
     values_files:
       - '{{ paths.root }}/{{ role_name }}/values.yml'
 
+# certificate
+- include_tasks: '{{ inventory_dir }}/roles/cert-manager/tasks/certificate.yml'
+
 # route
 - include_tasks: '{{ inventory_dir }}/roles/traefik/tasks/route.yml'
   vars:

--- a/roles/authelia/templates/authelia/certificate.yml.j2
+++ b/roles/authelia/templates/authelia/certificate.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: 'auth.{{ domain }}'
+  namespace: '{{ role_name }}'
+spec:
+  secretName: 'auth.{{ domain }}'
+  dnsNames:
+    - 'auth.{{ domain }}'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-manager-lets-encrypt

--- a/roles/authelia/templates/authelia/route.yml.j2
+++ b/roles/authelia/templates/authelia/route.yml.j2
@@ -22,3 +22,5 @@ spec:
           namespace: traefik
         - name: headers
           namespace: '{{ role_name }}'
+  tls:
+    secretName: 'auth.{{ domain }}'

--- a/roles/cert-manager/tasks/certificate.yml
+++ b/roles/cert-manager/tasks/certificate.yml
@@ -1,0 +1,4 @@
+- name: Create certificate
+  kubernetes.core.k8s:
+    state: present
+    template: '{{ path | default(role_name) }}/certificate.yml.j2'

--- a/roles/cert-manager/tasks/main.yml
+++ b/roles/cert-manager/tasks/main.yml
@@ -1,0 +1,36 @@
+# directories
+- name: Ensure directories exist
+  file:
+    path: '{{ paths.root }}/{{ item }}'
+    state: directory
+  loop:
+    - '{{ role_name }}'
+
+# namespace
+- include_tasks: '{{ inventory_dir }}/roles/k3s/tasks/namespace.yml'
+
+# cert-manager
+- name: Add helm repo
+  kubernetes.core.helm_repository:
+    name: jetstack
+    repo_url: https://charts.jetstack.io
+
+- name: Create chart values file
+  template:
+    src: '{{ role_name }}/values.yml.j2'
+    dest: '{{ paths.root }}/{{ role_name }}/values.yml'
+
+- name: Apply helm chart with values file
+  kubernetes.core.helm:
+    name: '{{ role_name }}'
+    chart_ref: 'jetstack/{{ role_name }}'
+    namespace: '{{ role_name }}'
+    update_repo_cache: yes
+    values_files:
+      - '{{ paths.root }}/{{ role_name }}/values.yml'
+
+# configuration
+- include_tasks: '{{ inventory_dir }}/roles/k3s/tasks/manifests.yml'
+  loop:
+    - secrets/digital-ocean
+    - issuer

--- a/roles/cert-manager/templates/cert-manager/issuer.yml.j2
+++ b/roles/cert-manager/templates/cert-manager/issuer.yml.j2
@@ -1,0 +1,16 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: '{{ role_name }}-lets-encrypt'
+spec:
+  acme:
+    email: '{{ vault.auth.email }}'
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: '{{ role_name }}-issuer-account-key'
+    solvers:
+      - dns01:
+          digitalocean:
+            tokenSecretRef:
+              name: '{{ role_name }}-digital-ocean-secret'
+              key: access-token

--- a/roles/cert-manager/templates/cert-manager/secrets/digital-ocean.yml.j2
+++ b/roles/cert-manager/templates/cert-manager/secrets/digital-ocean.yml.j2
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: '{{ role_name }}-digital-ocean-secret'
+  namespace: '{{ role_name }}'
+data:
+  access-token: '{{ vault.digital_ocean.token | b64encode }}'

--- a/roles/cert-manager/templates/cert-manager/values.yml.j2
+++ b/roles/cert-manager/templates/cert-manager/values.yml.j2
@@ -1,0 +1,11 @@
+# cert-manager/cert-manager
+# https://github.com/jetstack/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml
+installCRDs: true
+
+extraArgs:
+  - --dns01-recursive-nameservers-only
+  - --dns01-recursive-nameservers="1.1.1.1:53"
+
+extraEnv:
+  - name: TZ
+    value: '{{ timezone }}'

--- a/roles/code-server/tasks/main.yml
+++ b/roles/code-server/tasks/main.yml
@@ -30,5 +30,8 @@
     values_files:
       - '{{ paths.root }}/{{ role_name }}/values.yml'
 
+# certificate
+- include_tasks: '{{ inventory_dir }}/roles/cert-manager/tasks/certificate.yml'
+
 # route
 - include_tasks: '{{ inventory_dir }}/roles/traefik/tasks/route.yml'

--- a/roles/code-server/templates/code-server/certificate.yml.j2
+++ b/roles/code-server/templates/code-server/certificate.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: 'code.{{ domain }}'
+  namespace: '{{ role_name }}'
+spec:
+  secretName: 'code.{{ domain }}'
+  dnsNames:
+    - 'code.{{ domain }}'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-manager-lets-encrypt

--- a/roles/code-server/templates/code-server/route.yml.j2
+++ b/roles/code-server/templates/code-server/route.yml.j2
@@ -22,3 +22,5 @@ spec:
           namespace: traefik
         - name: error-pages
           namespace: traefik
+  tls:
+    secretName: 'code.{{ domain }}'

--- a/roles/gitlab/tasks/main.yml
+++ b/roles/gitlab/tasks/main.yml
@@ -45,5 +45,8 @@
     - { name: '{{ role_name }}', repo: 'pascaliske' }
     - { name: '{{ role_name }}-runner', repo: '{{ role_name }}' }
 
+# certificate
+- include_tasks: '{{ inventory_dir }}/roles/cert-manager/tasks/certificate.yml'
+
 # route
 - include_tasks: '{{ inventory_dir }}/roles/traefik/tasks/route.yml'

--- a/roles/gitlab/templates/gitlab/certificate.yml.j2
+++ b/roles/gitlab/templates/gitlab/certificate.yml.j2
@@ -1,0 +1,26 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: 'git.{{ domain }}'
+  namespace: '{{ role_name }}'
+spec:
+  secretName: 'git.{{ domain }}'
+  dnsNames:
+    - 'git.{{ domain }}'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-manager-lets-encrypt
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: 'registry.{{ domain }}'
+  namespace: '{{ role_name }}'
+spec:
+  secretName: 'registry.{{ domain }}'
+  dnsNames:
+    - 'registry.{{ domain }}'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-manager-lets-encrypt

--- a/roles/gitlab/templates/gitlab/route.yml.j2
+++ b/roles/gitlab/templates/gitlab/route.yml.j2
@@ -20,6 +20,8 @@ spec:
           namespace: traefik
         - name: error-pages
           namespace: traefik
+  tls:
+    secretName: 'git.{{ domain }}'
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
@@ -42,3 +44,5 @@ spec:
           namespace: traefik
         - name: error-pages
           namespace: traefik
+  tls:
+    secretName: 'registry.{{ domain }}'

--- a/roles/home-assistant/tasks/main.yml
+++ b/roles/home-assistant/tasks/main.yml
@@ -103,5 +103,8 @@
       - '{{ paths.root }}/{{ role_name }}/values.yml'
   register: helm
 
+# certificate
+- include_tasks: '{{ inventory_dir }}/roles/cert-manager/tasks/certificate.yml'
+
 # route
 - include_tasks: '{{ inventory_dir }}/roles/traefik/tasks/route.yml'

--- a/roles/home-assistant/templates/home-assistant/certificate.yml.j2
+++ b/roles/home-assistant/templates/home-assistant/certificate.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: 'homeassistant.{{ domain }}'
+  namespace: '{{ role_name }}'
+spec:
+  secretName: 'homeassistant.{{ domain }}'
+  dnsNames:
+    - 'homeassistant.{{ domain }}'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-manager-lets-encrypt

--- a/roles/home-assistant/templates/home-assistant/route.yml.j2
+++ b/roles/home-assistant/templates/home-assistant/route.yml.j2
@@ -23,3 +23,5 @@ spec:
           namespace: traefik
         - name: error-pages
           namespace: traefik
+  tls:
+    secretName: 'homeassistant.{{ domain }}'

--- a/roles/homer/tasks/main.yml
+++ b/roles/homer/tasks/main.yml
@@ -29,5 +29,8 @@
     values_files:
       - '{{ paths.root }}/{{ role_name }}/values.yml'
 
+# certificate
+- include_tasks: '{{ inventory_dir }}/roles/cert-manager/tasks/certificate.yml'
+
 # route
 - include_tasks: '{{ inventory_dir }}/roles/traefik/tasks/route.yml'

--- a/roles/homer/templates/homer/certificate.yml.j2
+++ b/roles/homer/templates/homer/certificate.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: '{{ domain }}'
+  namespace: '{{ role_name }}'
+spec:
+  secretName: '{{ domain }}'
+  dnsNames:
+    - '{{ domain }}'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-manager-lets-encrypt

--- a/roles/homer/templates/homer/route.yml.j2
+++ b/roles/homer/templates/homer/route.yml.j2
@@ -20,3 +20,5 @@ spec:
           namespace: traefik
         - name: error-pages
           namespace: traefik
+  tls:
+    secretName: '{{ domain }}'

--- a/roles/keel/tasks/main.yml
+++ b/roles/keel/tasks/main.yml
@@ -29,5 +29,8 @@
     values_files:
       - '{{ paths.root }}/{{ role_name }}/values.yml'
 
+# certificate
+- include_tasks: '{{ inventory_dir }}/roles/cert-manager/tasks/certificate.yml'
+
 # route
 - include_tasks: '{{ inventory_dir }}/roles/traefik/tasks/route.yml'

--- a/roles/keel/templates/keel/certificate.yml.j2
+++ b/roles/keel/templates/keel/certificate.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: '{{ role_name }}.{{ domain }}'
+  namespace: '{{ role_name }}'
+spec:
+  secretName: '{{ role_name }}.{{ domain }}'
+  dnsNames:
+    - '{{ role_name }}.{{ domain }}'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-manager-lets-encrypt

--- a/roles/keel/templates/keel/route.yml.j2
+++ b/roles/keel/templates/keel/route.yml.j2
@@ -22,3 +22,5 @@ spec:
           namespace: traefik
         - name: error-pages
           namespace: traefik
+  tls:
+    secretName: '{{ role_name }}.{{ domain }}'

--- a/roles/linkding/tasks/main.yml
+++ b/roles/linkding/tasks/main.yml
@@ -29,5 +29,8 @@
     values_files:
       - '{{ paths.root }}/{{ role_name }}/values.yml'
 
+# certificate
+- include_tasks: '{{ inventory_dir }}/roles/cert-manager/tasks/certificate.yml'
+
 # route
 - include_tasks: '{{ inventory_dir }}/roles/traefik/tasks/route.yml'

--- a/roles/linkding/templates/linkding/certificate.yml.j2
+++ b/roles/linkding/templates/linkding/certificate.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: 'links.{{ domain }}'
+  namespace: '{{ role_name }}'
+spec:
+  secretName: 'links.{{ domain }}'
+  dnsNames:
+    - 'links.{{ domain }}'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-manager-lets-encrypt

--- a/roles/linkding/templates/linkding/route.yml.j2
+++ b/roles/linkding/templates/linkding/route.yml.j2
@@ -22,3 +22,5 @@ spec:
           namespace: traefik
         - name: error-pages
           namespace: traefik
+  tls:
+    secretName: 'links.{{ domain }}'

--- a/roles/monitoring/tasks/services/alertmanager/main.yml
+++ b/roles/monitoring/tasks/services/alertmanager/main.yml
@@ -18,6 +18,11 @@
     values_files:
       - '{{ paths.root }}/{{ service }}/values.yml'
 
+# certificate
+- include_tasks: '{{ inventory_dir }}/roles/cert-manager/tasks/certificate.yml'
+  vars:
+    path: 'services/{{ service }}'
+
 # route
 - include_tasks: '{{ inventory_dir }}/roles/traefik/tasks/route.yml'
   vars:

--- a/roles/monitoring/tasks/services/grafana/main.yml
+++ b/roles/monitoring/tasks/services/grafana/main.yml
@@ -38,6 +38,11 @@
     values_files:
       - '{{ paths.root }}/{{ service }}/values.yml'
 
+# certificate
+- include_tasks: '{{ inventory_dir }}/roles/cert-manager/tasks/certificate.yml'
+  vars:
+    path: 'services/{{ service }}'
+
 # route
 - include_tasks: '{{ inventory_dir }}/roles/traefik/tasks/route.yml'
   vars:

--- a/roles/monitoring/tasks/services/loki/main.yml
+++ b/roles/monitoring/tasks/services/loki/main.yml
@@ -18,6 +18,11 @@
     values_files:
       - '{{ paths.root }}/{{ service }}/values.yml'
 
+# certificate
+- include_tasks: '{{ inventory_dir }}/roles/cert-manager/tasks/certificate.yml'
+  vars:
+    path: 'services/{{ service }}'
+
 # route
 - include_tasks: '{{ inventory_dir }}/roles/traefik/tasks/route.yml'
   vars:

--- a/roles/monitoring/tasks/services/prometheus/main.yml
+++ b/roles/monitoring/tasks/services/prometheus/main.yml
@@ -18,6 +18,11 @@
     values_files:
       - '{{ paths.root }}/{{ service }}/values.yml'
 
+# certificate
+- include_tasks: '{{ inventory_dir }}/roles/cert-manager/tasks/certificate.yml'
+  vars:
+    path: 'services/{{ service }}'
+
 # route
 - include_tasks: '{{ inventory_dir }}/roles/traefik/tasks/route.yml'
   vars:

--- a/roles/monitoring/templates/services/alertmanager/certificate.yml.j2
+++ b/roles/monitoring/templates/services/alertmanager/certificate.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: 'alerts.{{ domain }}'
+  namespace: '{{ role_name }}'
+spec:
+  secretName: 'alerts.{{ domain }}'
+  dnsNames:
+    - 'alerts.{{ domain }}'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-manager-lets-encrypt

--- a/roles/monitoring/templates/services/alertmanager/route.yml.j2
+++ b/roles/monitoring/templates/services/alertmanager/route.yml.j2
@@ -22,3 +22,5 @@ spec:
           namespace: traefik
         - name: error-pages
           namespace: traefik
+  tls:
+    secretName: 'alerts.{{ domain }}'

--- a/roles/monitoring/templates/services/grafana/certificate.yml.j2
+++ b/roles/monitoring/templates/services/grafana/certificate.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: '{{ service }}.{{ domain }}'
+  namespace: '{{ role_name }}'
+spec:
+  secretName: '{{ service }}.{{ domain }}'
+  dnsNames:
+    - '{{ service }}.{{ domain }}'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-manager-lets-encrypt

--- a/roles/monitoring/templates/services/grafana/route.yml.j2
+++ b/roles/monitoring/templates/services/grafana/route.yml.j2
@@ -22,3 +22,5 @@ spec:
           namespace: traefik
         - name: error-pages
           namespace: traefik
+  tls:
+    secretName: '{{ service }}.{{ domain }}'

--- a/roles/monitoring/templates/services/loki/certificate.yml.j2
+++ b/roles/monitoring/templates/services/loki/certificate.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: '{{ service }}.{{ domain }}'
+  namespace: '{{ role_name }}'
+spec:
+  secretName: '{{ service }}.{{ domain }}'
+  dnsNames:
+    - '{{ service }}.{{ domain }}'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-manager-lets-encrypt

--- a/roles/monitoring/templates/services/loki/route.yml.j2
+++ b/roles/monitoring/templates/services/loki/route.yml.j2
@@ -22,3 +22,5 @@ spec:
           namespace: traefik
         - name: error-pages
           namespace: traefik
+  tls:
+    secretName: '{{ service }}.{{ domain }}'

--- a/roles/monitoring/templates/services/prometheus/certificate.yml.j2
+++ b/roles/monitoring/templates/services/prometheus/certificate.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: '{{ service }}.{{ domain }}'
+  namespace: '{{ role_name }}'
+spec:
+  secretName: '{{ service }}.{{ domain }}'
+  dnsNames:
+    - '{{ service }}.{{ domain }}'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-manager-lets-encrypt

--- a/roles/monitoring/templates/services/prometheus/route.yml.j2
+++ b/roles/monitoring/templates/services/prometheus/route.yml.j2
@@ -22,3 +22,5 @@ spec:
           namespace: traefik
         - name: error-pages
           namespace: traefik
+  tls:
+    secretName: '{{ service }}.{{ domain }}'

--- a/roles/paperless/tasks/main.yml
+++ b/roles/paperless/tasks/main.yml
@@ -31,6 +31,9 @@
     values_files:
       - '{{ paths.root }}/{{ role_name }}/values.yml'
 
+# certificate
+- include_tasks: '{{ inventory_dir }}/roles/cert-manager/tasks/certificate.yml'
+
 # route
 - include_tasks: '{{ inventory_dir }}/roles/traefik/tasks/route.yml'
   vars:

--- a/roles/paperless/templates/paperless/certificate.yml.j2
+++ b/roles/paperless/templates/paperless/certificate.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: 'docs.{{ domain }}'
+  namespace: '{{ role_name }}'
+spec:
+  secretName: 'docs.{{ domain }}'
+  dnsNames:
+    - 'docs.{{ domain }}'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-manager-lets-encrypt

--- a/roles/paperless/templates/paperless/route.yml.j2
+++ b/roles/paperless/templates/paperless/route.yml.j2
@@ -24,3 +24,5 @@ spec:
           namespace: traefik
         - name: headers
           namespace: '{{ role_name }}'
+  tls:
+    secretName: 'docs.{{ domain }}'

--- a/roles/pihole/tasks/main.yml
+++ b/roles/pihole/tasks/main.yml
@@ -34,6 +34,9 @@
     values_files:
       - '{{ paths.root }}/{{ role_name }}/values.yml'
 
+# certificate
+- include_tasks: '{{ inventory_dir }}/roles/cert-manager/tasks/certificate.yml'
+
 # route
 - include_tasks: '{{ inventory_dir }}/roles/traefik/tasks/route.yml'
   vars:

--- a/roles/pihole/templates/pihole/certificate.yml.j2
+++ b/roles/pihole/templates/pihole/certificate.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: '{{ role_name }}.{{ domain }}'
+  namespace: '{{ role_name }}'
+spec:
+  secretName: '{{ role_name }}.{{ domain }}'
+  dnsNames:
+    - '{{ role_name }}.{{ domain }}'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-manager-lets-encrypt

--- a/roles/pihole/templates/pihole/route.yml.j2
+++ b/roles/pihole/templates/pihole/route.yml.j2
@@ -26,3 +26,5 @@ spec:
           namespace: '{{ role_name }}'
         - name: add-prefix
           namespace: '{{ role_name }}'
+  tls:
+    secretName: '{{ role_name }}.{{ domain }}'

--- a/roles/snapdrop/tasks/main.yml
+++ b/roles/snapdrop/tasks/main.yml
@@ -29,5 +29,8 @@
     values_files:
       - '{{ paths.root }}/{{ role_name }}/values.yml'
 
+# certificate
+- include_tasks: '{{ inventory_dir }}/roles/cert-manager/tasks/certificate.yml'
+
 # route
 - include_tasks: '{{ inventory_dir }}/roles/traefik/tasks/route.yml'

--- a/roles/snapdrop/templates/snapdrop/certificate.yml.j2
+++ b/roles/snapdrop/templates/snapdrop/certificate.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: 'drop.{{ domain }}'
+  namespace: '{{ role_name }}'
+spec:
+  secretName: 'drop.{{ domain }}'
+  dnsNames:
+    - 'drop.{{ domain }}'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-manager-lets-encrypt

--- a/roles/snapdrop/templates/snapdrop/route.yml.j2
+++ b/roles/snapdrop/templates/snapdrop/route.yml.j2
@@ -20,3 +20,5 @@ spec:
           namespace: traefik
         - name: error-pages
           namespace: traefik
+  tls:
+    secretName: 'drop.{{ domain }}'

--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -15,7 +15,6 @@
   loop:
     - tls-options
     - secrets/basic-auth
-    - secrets/digital-ocean
 
 # traefik + traefik-errors
 - name: Add helm repo
@@ -50,6 +49,9 @@
 - include_tasks: '{{ inventory_dir }}/roles/k3s/tasks/manifests.yml'
   loop:
     - service
+
+# certificate
+- include_tasks: '{{ inventory_dir }}/roles/cert-manager/tasks/certificate.yml'
 
 # route
 - include_tasks: '{{ inventory_dir }}/roles/traefik/tasks/route.yml'

--- a/roles/traefik/templates/traefik/certificate.yml.j2
+++ b/roles/traefik/templates/traefik/certificate.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: '{{ role_name }}.{{ domain }}'
+  namespace: '{{ role_name }}'
+spec:
+  secretName: '{{ role_name }}.{{ domain }}'
+  dnsNames:
+    - '{{ role_name }}.{{ domain }}'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-manager-lets-encrypt

--- a/roles/traefik/templates/traefik/route.yml.j2
+++ b/roles/traefik/templates/traefik/route.yml.j2
@@ -20,3 +20,5 @@ spec:
           namespace: '{{ role_name }}'
         - name: error-pages
           namespace: '{{ role_name }}'
+  tls:
+    secretName: '{{ role_name }}.{{ domain }}'

--- a/roles/traefik/templates/traefik/secrets/digital-ocean.yml.j2
+++ b/roles/traefik/templates/traefik/secrets/digital-ocean.yml.j2
@@ -1,9 +1,0 @@
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: '{{ role_name }}-digital-ocean-secret'
-  namespace: '{{ role_name }}'
-stringData:
-  email: '{{ vault.auth.email }}'
-  authToken: '{{ vault.digital_ocean.token }}'

--- a/roles/traefik/templates/traefik/values.yml.j2
+++ b/roles/traefik/templates/traefik/values.yml.j2
@@ -8,24 +8,12 @@ ingressRoute:
   dashboard:
     enabled: false
 
-persistence:
-  enabled: true
-
 # traefik specifics
 globalArguments:
   - --global.checknewversion=false
   - --global.sendanonymoususage=false
 
 additionalArguments:
-  # entry points
-  - '--entrypoints.https.http.tls.certresolver=digitalocean'
-
-  # certificates
-  - '--certificatesresolvers.digitalocean.acme.email={{ vault.auth.email }}'
-  - '--certificatesresolvers.digitalocean.acme.storage=/data/acme.json'
-  - '--certificatesresolvers.digitalocean.acme.dnschallenge.provider=digitalocean'
-  - '--certificatesresolvers.digitalocean.acme.dnschallenge.resolvers=1.1.1.1'
-
   # misc
   - '--providers.kubernetescrd.allowCrossNamespace=true'
   - '--serverstransport.insecureskipverify'
@@ -61,16 +49,6 @@ service:
 env:
   - name: TZ
     value: '{{ timezone }}'
-  - name: DO_API_EMAIL
-    valueFrom:
-      secretKeyRef:
-        name: '{{ role_name }}-digital-ocean-secret'
-        key: email
-  - name: DO_AUTH_TOKEN
-    valueFrom:
-      secretKeyRef:
-        name: '{{ role_name }}-digital-ocean-secret'
-        key: authToken
 
 logs:
   access:

--- a/roles/unifi/tasks/main.yml
+++ b/roles/unifi/tasks/main.yml
@@ -29,6 +29,9 @@
     values_files:
       - '{{ paths.root }}/{{ role_name }}/values.yml'
 
+# certificate
+- include_tasks: '{{ inventory_dir }}/roles/cert-manager/tasks/certificate.yml'
+
 # route
 - include_tasks: '{{ inventory_dir }}/roles/traefik/tasks/route.yml'
   vars:

--- a/roles/unifi/templates/unifi/certificate.yml.j2
+++ b/roles/unifi/templates/unifi/certificate.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: '{{ role_name }}.{{ domain }}'
+  namespace: '{{ role_name }}'
+spec:
+  secretName: '{{ role_name }}.{{ domain }}'
+  dnsNames:
+    - '{{ role_name }}.{{ domain }}'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-manager-lets-encrypt

--- a/roles/unifi/templates/unifi/route.yml.j2
+++ b/roles/unifi/templates/unifi/route.yml.j2
@@ -25,3 +25,5 @@ spec:
           namespace: traefik
         - name: headers
           namespace: '{{ role_name }}'
+  tls:
+    secretName: '{{ role_name }}.{{ domain }}'

--- a/roles/uptime-kuma/tasks/main.yml
+++ b/roles/uptime-kuma/tasks/main.yml
@@ -29,5 +29,8 @@
     values_files:
       - '{{ paths.root }}/{{ role_name }}/values.yml'
 
+# certificate
+- include_tasks: '{{ inventory_dir }}/roles/cert-manager/tasks/certificate.yml'
+
 # route
 - include_tasks: '{{ inventory_dir }}/roles/traefik/tasks/route.yml'

--- a/roles/uptime-kuma/templates/uptime-kuma/certificate.yml.j2
+++ b/roles/uptime-kuma/templates/uptime-kuma/certificate.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: 'status.{{ domain }}'
+  namespace: '{{ role_name }}'
+spec:
+  secretName: 'status.{{ domain }}'
+  dnsNames:
+    - 'status.{{ domain }}'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-manager-lets-encrypt

--- a/roles/uptime-kuma/templates/uptime-kuma/route.yml.j2
+++ b/roles/uptime-kuma/templates/uptime-kuma/route.yml.j2
@@ -22,3 +22,5 @@ spec:
           namespace: traefik
         - name: error-pages
           namespace: traefik
+  tls:
+    secretName: 'status.{{ domain }}'

--- a/roles/vaultwarden/tasks/main.yml
+++ b/roles/vaultwarden/tasks/main.yml
@@ -29,5 +29,8 @@
     values_files:
       - '{{ paths.root }}/{{ role_name }}/values.yml'
 
+# certificate
+- include_tasks: '{{ inventory_dir }}/roles/cert-manager/tasks/certificate.yml'
+
 # route
 - include_tasks: '{{ inventory_dir }}/roles/traefik/tasks/route.yml'

--- a/roles/vaultwarden/templates/vaultwarden/certificate.yml.j2
+++ b/roles/vaultwarden/templates/vaultwarden/certificate.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: 'vault.{{ domain }}'
+  namespace: '{{ role_name }}'
+spec:
+  secretName: 'vault.{{ domain }}'
+  dnsNames:
+    - 'vault.{{ domain }}'
+  issuerRef:
+    kind: ClusterIssuer
+    name: cert-manager-lets-encrypt

--- a/roles/vaultwarden/templates/vaultwarden/route.yml.j2
+++ b/roles/vaultwarden/templates/vaultwarden/route.yml.j2
@@ -22,6 +22,8 @@ spec:
           namespace: traefik
         - name: error-pages
           namespace: traefik
+  tls:
+    secretName: 'vault.{{ domain }}'
 ---
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
@@ -44,3 +46,5 @@ spec:
           namespace: traefik
         - name: security
           namespace: traefik
+  tls:
+    secretName: 'vault.{{ domain }}'


### PR DESCRIPTION
- [x] Setup [`cert-manager`](https://cert-manager.io/docs/installation/helm/) using [`cert-manager/cert-manager`](https://artifacthub.io/packages/helm/cert-manager/cert-manager)
- [x] Create a `ClusterIssuer` for a DNS01 challenge via DigitalOcean
- [x] Create `Certificate`s for all services
- [x] Configure all `IngressRoute`s with their respective `Certificate`s

https://www.padok.fr/en/blog/traefik-kubernetes-certmanager

Closes #68.