### PR TITLE
refactor: extract CRDs and install them separately

### DIFF
--- a/cluster/base/core.yaml
+++ b/cluster/base/core.yaml
@@ -9,6 +9,7 @@ spec:
   dependsOn:
     - name: config
     - name: charts
+    - name: crds
   path: ./cluster/core
   prune: false
   sourceRef:

--- a/cluster/base/crds.yaml
+++ b/cluster/base/crds.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: crds
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./cluster/crds
+  prune: false
+  sourceRef:
+    kind: GitRepository
+    name: flux-system

--- a/cluster/base/services.yaml
+++ b/cluster/base/services.yaml
@@ -9,6 +9,7 @@ spec:
   dependsOn:
     - name: config
     - name: charts
+    - name: crds
     - name: core
   path: ./cluster/services
   prune: true

--- a/cluster/core/cert-manager/helm-release.yaml
+++ b/cluster/core/cert-manager/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   chart:
     spec:
       chart: cert-manager
+      version: '1.10.1'
       reconcileStrategy: ChartVersion
       sourceRef:
         kind: HelmRepository
@@ -16,7 +17,7 @@ spec:
   install:
     createNamespace: true
   values:
-    installCRDs: true
+    installCRDs: false
     extraArgs:
       - --dns01-recursive-nameservers-only
       - --dns01-recursive-nameservers="1.1.1.1:53"

--- a/cluster/core/traefik/helm-release.yaml
+++ b/cluster/core/traefik/helm-release.yaml
@@ -16,33 +16,44 @@ spec:
         namespace: flux-system
   install:
     createNamespace: true
+    crds: Skip
+  upgrade:
+    crds: Skip
   values:
     image:
       name: traefik
       tag: 'v2.9.1'
+
     ingressRoute:
       dashboard:
         enabled: false
+
     providers:
       kubernetesCRD:
         allowCrossNamespace: true
+
     logs:
       access:
         enabled: true
         filters:
           statuscodes: 400-599
+
     metrics:
       prometheus:
         entryPoint: traefik
+
     globalArguments:
-      - --global.checknewversion=false
+      - --global.checknewversion=true
       - --global.sendanonymoususage=false
+
     additionalArguments:
       - '--ping.entrypoint=traefik'
       - '--serverstransport.insecureskipverify'
+
     env:
       - name: TZ
         value: ${TIMEZONE}
+
     ports:
       # services
       http:
@@ -54,11 +65,13 @@ spec:
         port: 9443
         expose: true
         exposedPort: 443
-      # metrics
+
+      # dashboard
       traefik:
         port: 9000
         expose: false
         exposedPort: 9000
+
       # disable default entry points
       web: null
       websecure: null
@@ -67,9 +80,12 @@ spec:
       default:
         minVersion: VersionTLS12
         sniStrict: true
+
     service:
+      single: true
       spec:
         externalTrafficPolicy: Local
+
     affinity:
       nodeAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:
@@ -77,6 +93,7 @@ spec:
             - matchExpressions:
                 - key: node-role.kubernetes.io/control-plane
                   operator: Exists
+
     tolerations:
       - key: node-role.kubernetes.io/control-plane
         operator: Exists

--- a/cluster/core/velero/helm-release.yaml
+++ b/cluster/core/velero/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   chart:
     spec:
       chart: velero
+      version: '2.32.3'
       reconcileStrategy: ChartVersion
       sourceRef:
         kind: HelmRepository
@@ -15,9 +16,9 @@ spec:
         namespace: flux-system
   install:
     createNamespace: true
-    crds: CreateReplace
+    crds: Skip
   upgrade:
-    crds: CreateReplace
+    crds: Skip
   values:
     image:
       repository: velero/velero

--- a/cluster/crds/README.md
+++ b/cluster/crds/README.md
@@ -1,0 +1,10 @@
+# CRDs
+
+Some services need [`CustomResourceDefinition`s](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/) to provide their functionalities. To prevent race conditions with the actual usage of those definitions, I've extracted the installation into a custom section which will be deployed **before** the [core](/cluster/core/) and [services](/cluster/services/) sections. Inside the corresponding `HelmRelease`s the deployment of CRDs is skipped.
+
+The following services require CRDs which are deployed by this section:
+
+- [`cert-manager`](/cluster/core/cert-manager/)
+- [`kube-prometheus-stack`](/cluster/services/monitoring/kube-prometheus-stack/)
+- [`traefik`](/cluster/core/traefik/)
+- [`velero`](/cluster/core/velero/)

--- a/cluster/crds/cert-manager/kustomization.yaml
+++ b/cluster/crds/cert-manager/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  # renovate: registryUrl=https://charts.jetstack.io chart=cert-manager
+  - https://github.com/jetstack/cert-manager/releases/download/v1.10.1/cert-manager.crds.yaml

--- a/cluster/crds/kube-prometheus-stack/crds.yaml
+++ b/cluster/crds/kube-prometheus-stack/crds.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: kube-prometheus-stack-crds
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: kube-prometheus-stack-source
+  interval: 15m
+  prune: false
+  healthChecks:
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: alertmanagerconfigs.monitoring.coreos.com
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: alertmanagers.monitoring.coreos.com
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: podmonitors.monitoring.coreos.com
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: probes.monitoring.coreos.com
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: prometheuses.monitoring.coreos.com
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: prometheusrules.monitoring.coreos.com
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: servicemonitors.monitoring.coreos.com
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: thanosrulers.monitoring.coreos.com

--- a/cluster/crds/kube-prometheus-stack/kustomization.yaml
+++ b/cluster/crds/kube-prometheus-stack/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - source.yaml
+  - crds.yaml

--- a/cluster/crds/kube-prometheus-stack/source.yaml
+++ b/cluster/crds/kube-prometheus-stack/source.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: kube-prometheus-stack-source
+  namespace: flux-system
+spec:
+  url: https://github.com/prometheus-community/helm-charts
+  ref:
+    # renovate: registryUrl=https://prometheus-community.github.io/helm-charts chart=kube-prometheus-stack
+    tag: kube-prometheus-stack-42.0.0
+  interval: 15m
+  ignore: |
+    # exclude all
+    /*
+    # include crds directory
+    !/charts/kube-prometheus-stack/crds

--- a/cluster/crds/kustomization.yaml
+++ b/cluster/crds/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cert-manager
+  - kube-prometheus-stack
+  - traefik
+  - velero

--- a/cluster/crds/traefik/crds.yaml
+++ b/cluster/crds/traefik/crds.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: traefik-crds
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: traefik-source
+  interval: 15m
+  prune: false
+  healthChecks:
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: ingressroutes.traefik.containo.us
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: ingressroutetcps.traefik.containo.us
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: ingressrouteudps.traefik.containo.us
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: middlewares.traefik.containo.us
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: middlewaretcps.traefik.containo.us
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: serverstransports.traefik.containo.us
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: tlsoptions.traefik.containo.us
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: tlsstores.traefik.containo.us
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: traefikservices.traefik.containo.us

--- a/cluster/crds/traefik/kustomization.yaml
+++ b/cluster/crds/traefik/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - source.yaml
+  - crds.yaml

--- a/cluster/crds/traefik/source.yaml
+++ b/cluster/crds/traefik/source.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: traefik-source
+  namespace: flux-system
+spec:
+  url: https://github.com/traefik/traefik-helm-chart
+  ref:
+    # renovate: registryUrl=https://traefik.github.io/charts
+    tag: v20.5.1
+  interval: 15m
+  ignore: |
+    # exclude all
+    /*
+    # include crds directory
+    !/traefik/crds

--- a/cluster/crds/velero/crds.yaml
+++ b/cluster/crds/velero/crds.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: velero-crds
+  namespace: flux-system
+spec:
+  sourceRef:
+    kind: GitRepository
+    name: velero-source
+  interval: 15m
+  prune: false
+  healthChecks:
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: backups.velero.io
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: backupstoragelocations.velero.io
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: deletebackuprequests.velero.io
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: downloadrequests.velero.io
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: podvolumebackups.velero.io
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: podvolumerestores.velero.io
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: resticrepositories.velero.io
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: restores.velero.io
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: schedules.velero.io
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: serverstatusrequests.velero.io
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: volumesnapshotlocations.velero.io

--- a/cluster/crds/velero/kustomization.yaml
+++ b/cluster/crds/velero/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - source.yaml
+  - crds.yaml

--- a/cluster/crds/velero/source.yaml
+++ b/cluster/crds/velero/source.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: GitRepository
+metadata:
+  name: velero-source
+  namespace: flux-system
+spec:
+  url: https://github.com/vmware-tanzu/helm-charts
+  ref:
+    # renovate: registryUrl=https://vmware-tanzu.github.io/helm-charts chart=velero
+    tag: velero-2.32.3
+  interval: 15m
+  ignore: |
+    # exclude all
+    /*
+    # include crds directory
+    !/charts/velero/crds

--- a/cluster/services/monitoring/kube-prometheus-stack/helm-release.yaml
+++ b/cluster/services/monitoring/kube-prometheus-stack/helm-release.yaml
@@ -8,6 +8,7 @@ spec:
   chart:
     spec:
       chart: kube-prometheus-stack
+      version: '42.0.0'
       reconcileStrategy: ChartVersion
       sourceRef:
         kind: HelmRepository
@@ -15,6 +16,9 @@ spec:
         namespace: flux-system
   install:
     createNamespace: true
+    crds: Skip
+  upgrade:
+    crds: Skip
   values:
     defaultRules:
       rules:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
       - Overview: cluster/base/index.md
       - Config: cluster/config/index.md
       - Charts: cluster/charts/index.md
+      - CRDs: cluster/crds/index.md
       - Core:
           - Overview: cluster/core/index.md
           - flux-system: cluster/core/flux-system/index.md


### PR DESCRIPTION
To prevent race conditions and duplicated folder structures (e.g. duplicate `traefik` folder in `core` & `services`), CRDs are extracted into a separate section which is deployed by flux before the `core` & `services` sections.