### PR TITLE
chore: revert registry.k8s.io/node-problem-detector/node-problem-detector back to v0.8.13

### DIFF
--- a/cluster/core/node-problem-detector/helm-release.yaml
+++ b/cluster/core/node-problem-detector/helm-release.yaml
@@ -17,7 +17,7 @@ spec:
   values:
     image:
       repository: registry.k8s.io/node-problem-detector/node-problem-detector
-      tag: v0.8.14
+      tag: v0.8.13
     metrics:
       enabled: true
       serviceMonitor:


### PR DESCRIPTION
Reverts pascaliske/infrastructure#1024.